### PR TITLE
Cant run from source.

### DIFF
--- a/pacvis/infos.py
+++ b/pacvis/infos.py
@@ -5,7 +5,7 @@ import re
 import pyalpm
 import pycman
 
-from .console import start_message, append_message, print_message
+from console import start_message, append_message, print_message
 
 
 class DbInfo:

--- a/pacvis/pacvis.py
+++ b/pacvis/pacvis.py
@@ -9,8 +9,8 @@ from webbrowser import open_new_tab
 import tornado.ioloop
 import tornado.web
 
-from .console import start_message, append_message, print_message
-from .infos import DbInfo, PkgInfo, GroupInfo, VDepInfo
+from console import start_message, append_message, print_message
+from infos import DbInfo, PkgInfo, GroupInfo, VDepInfo
 
 
 # Tornado entry


### PR DESCRIPTION
When running from source getting import error.
```Traceback (most recent call last):
  File "/home/robertbarnett/Documents/programming/pacvis/pacvis/pacvis.py", line 12, in <module>
    from .console import start_message, append_message, print_message
ImportError: attempted relative import with no known parent package```
While running from source ```pacvis.py``` can't import from ```console.py``` and ```infos.py``` due to the fact the they are referenced as ```.console``` and ```.infos```. Removing the period in ```.infos``` and ```.console``` seemed to fix the issue.

